### PR TITLE
fix: adjust eslint extends to use new name

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -4,7 +4,7 @@ module.exports = {
   extends: [
     '@taogilaaa/eslint-config-base',
     'xo-typescript',
-    'prettier/@typescript-eslint',
+    'prettier',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {


### PR DESCRIPTION
adjust eslint extends to use new name

* Adjust extends to use new name as reflected here
https://github.com/prettier/eslint-config-prettier/commit/03c79b9306892d4dbc828ce723813ef015baabc5